### PR TITLE
feat!: rescope to @kuraydev/react-native-picker-modal + packaging hygiene

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@freakycoder/react-native-picker-modal",
-  "version": "0.1.2",
+  "name": "@kuraydev/react-native-picker-modal",
+  "version": "1.0.0",
   "description": "Easy and fully customizable picker modal for React Native.",
   "main": "./build/dist/PickerModal.js",
-  "repository": "git@github.com:WrathChaos/react-native-picker-modal.git",
+  "repository": "git@github.com:kuraydev/react-native-picker-modal.git",
   "author": "FreakyCoder <kurayogun@gmail.com>",
   "license": "MIT",
   "homepage": "https://www.freakycoder.com",
@@ -48,5 +48,23 @@
     "semantic-release": "semantic-release",
     "copy:assets": "cpx 'lib/local-assets/**' './build/dist/local-assets'",
     "copy:package": "cpx '../package.json' '../build/dist/'"
-  }
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-native": ">=0.64.0"
+  },
+  "types": "./build/dist/PickerModal.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/dist/PickerModal.d.ts",
+      "default": "./build/dist/PickerModal.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "build",
+    "lib",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
Prep for the @freakycoder → kuraydev npm migration (scopes can't transfer). Renames to @kuraydev/react-native-picker-modal@1.0.0, adds missing react/react-native peerDependencies, a types/exports map matching the published tarball, a files whitelist (tarball was shipping .husky/, .github/ and dotfiles), and points repository at kuraydev. The react-native-modal dependency is kept — it is genuinely imported in lib/PickerModal.tsx. Publish as @kuraydev/react-native-picker-modal@1.0.0 once the new npm account exists, then deprecate the old scoped package with a pointer to the new name.